### PR TITLE
chore(deps): bump minor + patch dependencies (verified, tests green)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,27 +38,27 @@
   },
   "homepage": "https://github.com/nearform/netsuite-restlet-api#readme",
   "devDependencies": {
-    "@commitlint/cli": "^21.0.0",
-    "@commitlint/config-conventional": "^21.0.0",
+    "@commitlint/cli": "^21.2.0",
+    "@commitlint/config-conventional": "^21.2.0",
     "@eslint/js": "^10.0.1",
     "@types/jsrsasign": "^10.5.15",
-    "@types/node": "^26.0.0",
-    "eslint": "^10.0.2",
-    "eslint-config-prettier": "^10.0.2",
-    "eslint-plugin-prettier": "^5.2.3",
-    "globals": "^17.0.0",
+    "@types/node": "^26.1.0",
+    "eslint": "^10.6.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.6",
+    "globals": "^17.7.0",
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.5",
-    "prettier": "^3.5.3",
-    "tsx": "^4.19.3",
-    "typescript": "^5.7.3",
-    "typescript-eslint": "^8.25.0",
-    "undici": "^7.4.0"
+    "lint-staged": "^17.0.8",
+    "prettier": "^3.9.4",
+    "tsx": "^4.23.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.62.1",
+    "undici": "^7.28.0"
   },
   "lint-staged": {
     "*.{js,jsx}": "eslint --cache --fix"
   },
   "dependencies": {
-    "jsrsasign": "^11.1.0"
+    "jsrsasign": "^11.1.3"
   }
 }


### PR DESCRIPTION
Batches available **minor + patch** upgrades (14 packages, no majors) into one PR. Baseline `npm test` green **before**, and green **after** the bump. All available minor/patch upgrades. Companion PR adds dependabot minor/patch grouping. For human review + merge — not merging anything.