### PR TITLE
chore: consolidate open Dependabot updates (typescript 6, undici 8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lint-staged": "^17.0.5",
         "prettier": "^3.5.3",
         "tsx": "^4.19.3",
-        "typescript": "^5.7.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.25.0",
         "undici": "^7.4.0"
       }
@@ -2584,10 +2584,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4332,9 +4333,9 @@
       }
     },
     "typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true
     },
     "typescript-eslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "tsx": "^4.19.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.25.0",
-        "undici": "^7.4.0"
+        "undici": "^8.10.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2621,12 +2621,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -4351,9 +4352,9 @@
       }
     },
     "undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint-staged": "^17.0.5",
     "prettier": "^3.5.3",
     "tsx": "^4.19.3",
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.25.0",
     "undici": "^7.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "tsx": "^4.19.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.25.0",
-    "undici": "^7.4.0"
+    "undici": "^8.10.0"
   },
   "lint-staged": {
     "*.{js,jsx}": "eslint --cache --fix"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, before, afterEach, mock, describe, it } from 'node:test'
-import { MockAgent, setGlobalDispatcher } from 'undici'
+import { MockAgent, install, setGlobalDispatcher } from 'undici'
 import assert from 'node:assert'
 import {
   MOCK_CONFIG,
@@ -14,10 +14,23 @@ describe('NetSuiteClient.get', () => {
 
   beforeEach(() => {
     agent = new MockAgent()
+    // Turn an unmatched request into an explicit MockNotMatchedError instead of
+    // a live call. Note this only covers requests that reach MockAgent's
+    // interceptor layer; it does not catch a dispatcher-level bypass like the
+    // one described in the before() hook below.
+    agent.disableNetConnect()
     setGlobalDispatcher(agent)
   })
 
   before(async () => {
+    // Route globalThis.fetch through undici's own fetch so that MockAgent can
+    // intercept it. Node's built-in fetch reaches the global dispatcher through
+    // a wrapper that forces `allowH2: false`, which from undici 8.0.3 makes the
+    // agent look up an `<origin>#http1-only` client key that MockAgent never
+    // registers -- the request then escapes to the real network. See
+    // nodejs/undici#5036; the fix is merged but unreleased as of undici 8.10.0.
+    install()
+
     mock.module('jsrsasign', {
       namedExports: {
         KJUR: {

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/cjs",
+    "tsBuildInfoFile": "./dist/cjs/tsconfig.cjs.tsbuildinfo",
     "module": "CommonJS",
     "declaration": true
   }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/esm",
+    "tsBuildInfoFile": "./dist/esm/tsconfig.esm.tsbuildinfo",
     "module": "ESNext",
     "declaration": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
Consolidates both of the repository's open Dependabot pull requests into one verified change.

Closes #358

## What is in here

| Dependabot PR | Package | From → To |
| --- | --- | --- |
| #272 | `typescript` (devDep) | 5.9.3 → 6.0.3 |
| #347 | `undici` (devDep) | 7.29.0 → 8.10.0 |

Nothing is left out. Both bumps are `devDependencies`; **`dependencies` (`jsrsasign ^11.1.0`) is
untouched and the package declares no `peerDependencies`, so the consumer contract of the published
package does not change.**

Exactly two *packages* move in `package-lock.json` — `node_modules/typescript` and
`node_modules/undici` — both at versions (and integrity hashes) matching Dependabot's own branches.
Because the lockfile is `lockfileVersion: 2` that shows up as five changed JSON entries: those two,
the root `packages[""]` devDependency specs, and the legacy `dependencies.typescript` /
`dependencies.undici` mirrors. The lockfile stays on `lockfileVersion: 2`, the entry count is
unchanged at 204, and nothing moved between hoisted and nested positions (compared path-keyed, not
name-keyed). A control `npm install` on an unmodified `master` checkout with the same npm produced
a **zero-line** lockfile diff, so none of the diff below is npm-version churn. No in-range drift
was picked up either: `@commitlint/cli`, `@types/node`, `eslint`, `lint-staged` and
`typescript-eslint` all have newer versions available and are deliberately left for Dependabot.

Both PRs have been red for a long time (#272 since April), and in neither case was the cause a
lockfile problem. Each needed a small, specific fix.

---

## 1. TypeScript 6 needs an explicit `rootDir`

`typescript@6` fails the existing build outright:

```
tsconfig.cjs.json(4,5): error TS5011: The common source directory of 'tsconfig.cjs.json' is
'./src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your
output's file layout.
```

TypeScript 6 no longer infers the common source directory when `outDir` is set, so `tsconfig.json`
now declares the `./src` root the compiler previously computed.

Setting `rootDir` has one side effect worth calling out: it also changes where `tsc -b` computes
the default `.tsbuildinfo` path, moving both files from `dist/cjs/` and `dist/esm/` up to `dist/`.
Because `package.json` ships `"files": ["dist"]`, that would have quietly changed the layout of the
published tarball. `tsBuildInfoFile` is therefore pinned to the original locations in
`tsconfig.cjs.json` / `tsconfig.esm.json`, in its own commit.

**The published output is effectively unchanged.** Built with TypeScript 6.0.3 versus 5.9.3 on
`master`, `dist/` has an identical file set (`npm pack --dry-run` lists the same files at the same
sizes), and all eight emitted files — `dist/esm/index.js`, `dist/esm/types.js`,
`dist/esm/index.d.ts`, `dist/esm/types.d.ts`, `dist/cjs/index.cjs`, `dist/cjs/types.cjs`,
`dist/cjs/index.d.cts`, `dist/cjs/types.d.cts` — are byte-identical (`cmp`). The only difference
anywhere under `dist/` is the compiler version string recorded inside the two incremental-build
files:

```
< {"root":["../../src/index.ts","../../src/types.ts"],"version":"5.9.3"}
> {"root":["../../src/index.ts","../../src/types.ts"],"version":"6.0.3"}
```

(Those `.tsbuildinfo` files being inside `"files"` at all is a pre-existing packaging wart; it is
left alone here.)

### TypeScript 7 was evaluated and rejected

`typescript@7.0.2` is the current `latest`. It actually compiles this project fine once `rootDir`
is set — but it cannot land yet, because `typescript-eslint` will not accept it. Its `typescript`
peer range is `>=4.8.4 <6.1.0` on the current `8.68.0`, and across all published versions the
upper bound has only ever been `<5.8.0`, `<5.9.0`, `<6.0.0` or `<6.1.0` (`<6.1.0` first appears in
`8.58.0`); the `canary` tag is no different. Installing TypeScript 7 makes `npm ls --all` exit 1
with an invalid peer and forces the whole `@typescript-eslint/*` subtree to nest, growing the
lockfile from 204 to 224 entries. `6.0.3` — Dependabot's own target — is the highest version that
keeps the tree peer-clean.

---

## 2. undici 8 needs the tests to stop relying on Node's built-in `fetch`

`src/index.ts` calls Node's **built-in global `fetch`**, and the tests intercept it with
`MockAgent` + `setGlobalDispatcher`. undici 8 routes the legacy global dispatcher slot that Node's
bundled fetch reads through a `Dispatcher1Wrapper`; in **8.0.3** that wrapper started forcing
`allowH2: false` (nodejs/undici#4989), which collides with the `` `${origin}#http1-only` `` client
key `Agent[kDispatch]` gained in 8.0.2. `MockAgent.get(origin)` still registers its `MockPool`
under the plain `origin`, so the lookup misses, a real client is created, and **the request escapes
to the public internet** — which is why the failure looks like a data bug
(`SyntaxError: Unexpected token '<', "<!DOCTYPE "...`) rather than a missing interceptor.

Measured locally on Node 24 with `npm test` and the unmodified test file:

| undici | result |
| --- | --- |
| 7.29.0 | pass |
| 8.0.0 | fail — separate, earlier bug: `lib/global.js` guarded the legacy-slot write with `if (nodeMajor === 22)` |
| 8.0.1 | pass |
| 8.0.2 | pass |
| 8.0.3 | fail — the `allowH2` collision described above |
| 8.10.0 | fail |

The fix here is two lines in `test/index.test.ts`: call undici's `install()` before the suite runs.
That routes the globals through undici's own implementation, which reads the unwrapped dispatcher
slot and is intercepted correctly. `install()` is public, documented and `Stability: 2 - Stable`
(`docs/docs/api/GlobalInstallation.md`, added in undici 7.11.0). It is version-neutral — the test
change passes on the currently pinned 7.29.0 as well, which is why it is a separate commit from the
bump.

**Honest tradeoff:** `install()` overwrites ten globals process-wide for the lifetime of the
process — `fetch`, `Headers`, `Response`, `Request`, `FormData`, `WebSocket`, `CloseEvent`,
`ErrorEvent`, `MessageEvent`, `EventSource` — and the suite therefore exercises userland undici's
`fetch` rather than Node's bundled one. Only `fetch` matters to this library today, but it is a
real reduction in fidelity and should be reverted once an undici 8.x release carries the upstream
fix: nodejs/undici#5648 was merged on 2026-08-05 and closed nodejs/undici#5036, but 8.10.0 was
published on 2026-08-03 and therefore predates it — and 8.10.0 still reproduces the bug locally.
#359 records the analysis and the follow-up.

`agent.disableNetConnect()` is also added so that an ordinary unmatched request fails as a
`MockNotMatchedError` instead of silently going to the network. It does *not* guard against the
dispatcher-level bypass above — with `install()` removed and `disableNetConnect()` left in place,
undici 8.10.0 still reaches the live host — and the code comment says so.

**One thing to be aware of:** undici 8's own `engines.node` is `>=22.19.0`, up from `>=20.18.1` on
7.29.0. This repo declares no `engines` and `.nvmrc` is `lts/*`, so CI is unaffected, but a
contributor still on Node 20 will now get `EBADENGINE` on install.

---

## Note on #272's age

#272 was opened on 2026-04-20 and last touched on 2026-05-25, so its branch predates four months of
`master`. Merging it would not have regressed anything — a merge only applies what the branch
changed, and it changed nothing outside the `typescript` lines — but its tree is far enough behind
that the bump was rebuilt from `master` here rather than rebased.

---

## Verification

Run on Node 24.18.0 / npm 11.16.0 locally. CI resolves `.nvmrc` (`lts/*`) to the current Node 24
LTS — the most recent CI run on this repo used 24.19.0 — so this is the same major and the same
npm 11 line, not the shell default of Node 22 / npm 12.

| Check | `master` | this branch |
| --- | --- | --- |
| `npm ci` | pass, lockfile untouched | pass, lockfile untouched |
| `npm run build` | pass | pass |
| `npm run lint` | pass | pass |
| `npm test` | 2/2 pass | 2/2 pass |
| `npm ls --all` | exit 0 | exit 0 |
| clean-tree `npm install` from `git archive` | — | exit 0, zero lockfile drift |

That is the exact command sequence the `Lint and test` job runs. All four commits are also
independently green.

### What the tests do and do not prove

This is a Node library — it calls Node's global `fetch` and is consumed from Node — not SuiteScript
running inside NetSuite's runtime, so the suite does exercise the real shipped code path. But it is
two tests, and they cover the request path narrowly. Mutation checks confirm what is genuinely
asserted: changing the request URL, changing the HTTP method, or disabling access-token reuse each
turns the suite red. Changing or **removing the `Authorization` header does not** — the suite
proves the token is minted once, not that it is ever sent.

Everything below the client — the actual NetSuite RESTlet contract, a real OAuth token exchange,
and `jsrsasign`'s PS256 signing, which the tests mock out — is **not** exercised by CI, on this
branch or on `master`. For the TypeScript bump the stronger signal is the byte-identical `dist/`
comparison above; for the undici bump it is that those assertions pass against a genuinely
intercepted request, which `master` cannot do at all on 8.10.0.
